### PR TITLE
Fixes `tmapreduce` and `tmapadd` for v0.7 using batch loads

### DIFF
--- a/src/KissThreading.jl
+++ b/src/KissThreading.jl
@@ -54,9 +54,12 @@ function tmap!(f::Function, dst::AbstractVector, src::AbstractVector...)
     end
 end
 
+default_batch_size(n) = min(n, round(Int, 10*sqrt(n)))
+
 # we assume that f(src) is a subset of Abelian group with op
 # and that v0 is its identity
-function tmapreduce(f::Function, op::Function, v0::T, src::AbstractVector) where T 
+
+function tmapreduce(f::Function, op::Function, v0::T, src::AbstractVector; batch_size=default_batch_size(length(src))) where T 
     r = deepcopy(v0)
     i = Threads.Atomic{Int}(1)
     l = Threads.SpinLock()
@@ -64,15 +67,23 @@ function tmapreduce(f::Function, op::Function, v0::T, src::AbstractVector) where
     nt = Threads.nthreads()
     return let r::T = r;
         Threads.@threads for j in 1:nt
-            k = Threads.atomic_add!(i, 1)
-            x = f(src[k])
-            while true
-                k = Threads.atomic_add!(i, 1)
-                if k ≤ ls
-                    x = op(x, f(src[k]))
-                else
-                    break
+            k = Threads.atomic_add!(i, batch_size)
+            if k <= ls
+                x = f(src[k])
+                range = (k+1):min(k+batch_size-1, ls)
+                for idx in range
+                    x = op(x, f(src[idx]))
                 end
+            else
+                continue
+            end
+            k = Threads.atomic_add!(i, batch_size)
+            while k ≤ ls
+                range = k:min(k+batch_size-1, ls)
+                for idx in range
+                    x = op(x, f(src[idx]))
+                end
+                k = Threads.atomic_add!(i, batch_size)
             end
             Threads.lock(l)
             r = op(r, x)
@@ -82,71 +93,114 @@ function tmapreduce(f::Function, op::Function, v0::T, src::AbstractVector) where
     end
 end
 
-function tmapreduce(f::Function, op::Function, v0, src::AbstractVector...)
+function tmapreduce(f::Function, op::Function, v0::T, src::AbstractVector...; batch_size=default_batch_size(length(src[1]))) where T
     lss = extrema(length.(src))
-    lss[1] == lss[2] || throw(ArgumentError("src vectors must have the same lenth"))
-    ls = lss[1]
-    l = Threads.SpinLock()
-    i = Threads.Atomic{Int}(1)
+    lss[1] == lss[2] || throw(ArgumentError("src vectors must have the same length"))
 
     r = deepcopy(v0)
-    Threads.@threads for j in 1:Threads.nthreads()
-        k = Threads.atomic_add!(i, 1)
-        x = f(getindex.(src, k)...)
-        while true
-            k = Threads.atomic_add!(i, 1)
-            if k ≤ ls
-                x = op(x, f(getindex.(src,k)...))
+    i = Threads.Atomic{Int}(1)
+    l = Threads.SpinLock()
+    ls = lss[1]
+    nt = Threads.nthreads()
+    return let r::T = r;
+        Threads.@threads for j in 1:nt
+            k = Threads.atomic_add!(i, batch_size)
+            if k <= ls
+                x = f(getindex.(src, k)...)
+                range = (k+1):min(k+batch_size-1, ls)
+                for idx in range
+                    x = op(x, f(getindex.(src, idx)...))
+                end
             else
-                break
+                continue
             end
+            k = Threads.atomic_add!(i, batch_size)
+            while k ≤ ls
+                range = k:min(k+batch_size-1, ls)
+                for idx in range
+                    x = op(x, f(getindex.(src, idx)...))
+                end
+                k = Threads.atomic_add!(i, batch_size)
+            end
+            Threads.lock(l)
+            r = op(r, x)
+            Threads.unlock(l)
         end
-        Threads.lock(l)
-        r = op(r, x)
-        Threads.unlock(l)
+        r
     end
-    return r
 end
 
-function tmapadd(f::Function, v0, src::AbstractVector)
+function tmapadd(f::Function, v0::T, src::AbstractVector; batch_size=default_batch_size(length(src))) where T
+    r = Threads.Atomic{T}(deepcopy(v0))
+    i = Threads.Atomic{Int}(1)
     ls = length(src)
-    i = Threads.Atomic{Int}(1)
-    r = Threads.Atomic{typeof(v0)}(zero(v0))
-    Threads.@threads for j in 1:Threads.nthreads()
-        x = zero(v0)
-        while true
-            k = Threads.atomic_add!(i, 1)
-            if k ≤ ls
-                @inbounds x += f(src[k])
-            else
-                break
+    nt = Threads.nthreads()
+    Threads.@threads for j in 1:nt
+        k = Threads.atomic_add!(i, batch_size)
+        if k <= ls
+            x = f(src[k])
+            range = (k+1):min(k+batch_size-1, ls)
+            for idx in range
+                x += f(src[idx])
             end
+        else
+            continue
+        end
+        k = Threads.atomic_add!(i, batch_size)
+        while k ≤ ls
+            range = k:min(k+batch_size-1, ls)
+            for idx in range
+                x += f(src[idx])
+            end
+            k = Threads.atomic_add!(i, batch_size)
         end
         Threads.atomic_add!(r, x)
     end
-    return v0 + r[]
+    return r[]
 end
 
-function tmapadd(f::Function, v0, src::AbstractVector...)
-    ls = length(src[1])
+function tmapadd(f::Function, v0::T, src::AbstractVector...; batch_size=default_batch_size(length(src[1]))) where T
+    lss = extrema(length.(src))
+    lss[1] == lss[2] || throw(ArgumentError("src vectors must have the same length"))
+
+    r = Threads.Atomic{T}(deepcopy(v0))
     i = Threads.Atomic{Int}(1)
-    r = Threads.Atomic{typeof(v0)}(zero(v0))
-    Threads.@threads for j in 1:Threads.nthreads()
-        x = zero(v0)
-        while true
-            k = Threads.atomic_add!(i, 1)
-            if k ≤ ls
-                x += f(getindex.(src, k)...)
-            else
-                break
+    ls = lss[1]
+    nt = Threads.nthreads()
+    Threads.@threads for j in 1:nt
+        k = Threads.atomic_add!(i, batch_size)
+        if k <= ls
+            x = f(getindex.(src, k)...)
+            range = (k+1):min(k+batch_size-1, ls)
+            for idx in range
+                x += f(getindex.(src, idx)...)
             end
+        else
+            continue
+        end
+        k = Threads.atomic_add!(i, batch_size)
+        while k ≤ ls
+            range = k:min(k+batch_size-1, ls)
+            for idx in range
+                x += f(getindex.(src, idx)...)
+            end
+            k = Threads.atomic_add!(i, batch_size)
         end
         Threads.atomic_add!(r, x)
     end
-    return v0 + r[]
+    return r[]
 end
 
 function getrange(n)
+    tid = Threads.threadid()
+    nt = Threads.nthreads()
+    d , r = divrem(n, nt)
+    from = (tid - 1) * d + min(r, tid - 1) + 1
+    to = from + d - 1 + (tid ≤ r ? 1 : 0)
+    from:to
+end
+
+function getrange(n, k, bs)
     tid = Threads.threadid()
     nt = Threads.nthreads()
     d , r = divrem(n, nt)

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -1,0 +1,21 @@
+@testset "mapreduce" begin
+    println("--------")
+    println("threaded: $(Threads.nthreads()) threads")
+    n = 10000000
+    a = rand(n)
+    tmapadd(log, 0., a)
+    @time tmapadd(log, 0., a)
+    println("unthreaded")
+    mapreduce(log, +, a, init=0.)
+    @time mapreduce(log, +, a, init=0.)
+
+    @test tmapreduce(log, +, 0., ones(1000)) == 0
+    srand(1234321)
+    a = rand(1000)
+    r1 = tmapreduce((x)->(2*x), +, 0., a)
+    r2 = mapreduce((x)->(2*x), +, a, init=0.)
+    @test r1 ≈ r2
+
+    r3 = tmapadd((x)->(2*x), 0., a)
+    @test r1 ≈ r3
+end

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -1,10 +1,15 @@
 @testset "mapreduce" begin
     println("--------")
-    println("threaded: $(Threads.nthreads()) threads")
     n = 10000000
     a = rand(n)
+    println("threaded tmapreduce: $(Threads.nthreads()) threads")
+    tmapreduce(log, +, 0., a)
+    @time tmapreduce(log, +, 0., a)
+
+    println("threaded tmapadd: $(Threads.nthreads()) threads")
     tmapadd(log, 0., a)
     @time tmapadd(log, 0., a)
+
     println("unthreaded")
     mapreduce(log, +, a, init=0.)
     @time mapreduce(log, +, a, init=0.)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,12 @@
 using Test
 using KissThreading
-using Random: GLOBAL_RNG
+using Random: GLOBAL_RNG, srand
 using Statistics: std, mean
 
 include("bootstrap.jl")
 include("bubblesort.jl")
 include("sort_batch.jl")
 include("summation.jl")
+include("mapreduce.jl")
 
 println("========")


### PR DESCRIPTION
This PR is based on https://github.com/bkamins/KissThreading.jl/pull/2. It does batch load dispatch to threads achieving near linear (sometimes super-linear) scaling in test cases. Feedback appreciated!

Closes https://github.com/bkamins/KissThreading.jl/issues/1.