### PR TITLE
tmapreduce refactor using callables and manual inference & tmap! cleanup

### DIFF
--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -1,6 +1,6 @@
 @testset "mapreduce" begin
     println("--------")
-    n = 10000000
+    n = 100000000
     a = rand(n)
     println("threaded tmapreduce: $(Threads.nthreads()) threads")
     tmapreduce(log, +, a, init=0.0)


### PR DESCRIPTION
This PR does the following:
1. Uses manual inference in `tmapreduce` to ensure type stability even when `typeof(init)` is not the same as `typeof(f(src[1]))` which may also be different from `typeof(op(init, f(src[1])))`, as long as `Base.convert` is defined appropriately, e.g. `init` can be an `Integer` now when the output is `Float64` not a problem.
2. Uses callables to ensure type stability and eliminate the closure bug. This is a more Julian way of eliminating the closure bug than the `Ref` trick. Also I think this what elrod meant in https://discourse.julialang.org/t/type-inference-in-closures/12544/4. It is also what tamas suggested in https://discourse.julialang.org/t/unrecommended-style-of-programming-in-julia-for-type-stability/7672/5 and stephan seconded in https://discourse.julialang.org/t/unrecommended-style-of-programming-in-julia-for-type-stability/7672/11 saying that that's how closures are implemented under the hood anyways.
3. Removes the redundant single src input versions of tmap! and tmapreduce, as the vararg version covers that case nicely and the compiler should do all the specializations needed when only 1 src is input.
4. Uses a batch size of 1 in tmap! since I found no speedup when using the default batch size function. Something fishy is going on.
5. Increases the test problem size of `tmapreduce` to make it run for 1 second on my machine when unthreaded.
6. Minor cleanup of tmap!
